### PR TITLE
fix: enforce special character in password

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -51,13 +51,19 @@ export const AuthForm = ({ onSuccess }: AuthFormProps) => {
     const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
     
     return {
-      isValid: minLength && hasUpperCase && hasLowerCase && hasNumbers,
+      isValid:
+        minLength &&
+        hasUpperCase &&
+        hasLowerCase &&
+        hasNumbers &&
+        hasSpecialChar,
       suggestions: [
         !minLength && "8 أحرف على الأقل",
         !hasUpperCase && "حرف كبير واحد على الأقل",
-        !hasLowerCase && "حرف صغير واحد على الأقل", 
-        !hasNumbers && "رقم واحد على الأقل"
-      ].filter(Boolean)
+        !hasLowerCase && "حرف صغير واحد على الأقل",
+        !hasNumbers && "رقم واحد على الأقل",
+        !hasSpecialChar && "رمز خاص واحد على الأقل",
+      ].filter(Boolean),
     };
   };
 


### PR DESCRIPTION
## Summary
- strengthen password validation by requiring at least one special character

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68905c0d2ab08328a38b3b30a0df5793