### PR TITLE
Restrict profile RLS view policy to owner or admins

### DIFF
--- a/supabase/migrations/20250803060000_update_profiles_view_policy.sql
+++ b/supabase/migrations/20250803060000_update_profiles_view_policy.sql
@@ -1,0 +1,9 @@
+-- Restrict profile viewing to owner or administrative roles
+DROP POLICY IF EXISTS "Users can view all profiles" ON public.profiles;
+
+CREATE POLICY "Users can view own profile or admin" ON public.profiles
+    FOR SELECT USING (
+        auth.uid() = user_id
+        OR public.has_role(auth.uid(), 'admin'::app_role)
+        OR public.has_role(auth.uid(), 'accountant'::app_role)
+    );


### PR DESCRIPTION
## Summary
- Drop legacy open `public.profiles` view policy and recreate it so only the profile owner or users with `admin`/`accountant` roles can view profiles.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: ERESOLVE could not resolve dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689076dd37d88328937b764081a43be6