### PR TITLE
feat: use enums for property and status fields

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -385,7 +385,7 @@ export type Database = {
           paid_at: string | null
           percentage: number
           remaining_for_employees: number | null
-          status: string
+            status: Database["public"]["Enums"]["commission_status"]
           total_commission: number | null
           updated_at: string
         }
@@ -401,7 +401,7 @@ export type Database = {
           paid_at?: string | null
           percentage: number
           remaining_for_employees?: number | null
-          status?: string
+            status?: Database["public"]["Enums"]["commission_status"]
           total_commission?: number | null
           updated_at?: string
         }
@@ -417,7 +417,7 @@ export type Database = {
           paid_at?: string | null
           percentage?: number
           remaining_for_employees?: number | null
-          status?: string
+            status?: Database["public"]["Enums"]["commission_status"]
           total_commission?: number | null
           updated_at?: string
         }
@@ -547,7 +547,7 @@ export type Database = {
           office_share: number
           paid_at: string | null
           property_title: string | null
-          status: string
+          status: Database["public"]["Enums"]["commission_status"]
           total_amount: number
           updated_at: string
         }
@@ -568,7 +568,7 @@ export type Database = {
           office_share?: number
           paid_at?: string | null
           property_title?: string | null
-          status?: string
+          status?: Database["public"]["Enums"]["commission_status"]
           total_amount?: number
           updated_at?: string
         }
@@ -589,7 +589,7 @@ export type Database = {
           office_share?: number
           paid_at?: string | null
           property_title?: string | null
-          status?: string
+          status?: Database["public"]["Enums"]["commission_status"]
           total_amount?: number
           updated_at?: string
         }
@@ -625,7 +625,7 @@ export type Database = {
           id: string
           notes: string | null
           property_id: string
-          status: string
+              status: Database["public"]["Enums"]["deal_status"]
           updated_at: string
         }
         Insert: {
@@ -642,7 +642,7 @@ export type Database = {
           id?: string
           notes?: string | null
           property_id: string
-          status?: string
+              status?: Database["public"]["Enums"]["deal_status"]
           updated_at?: string
         }
         Update: {
@@ -659,7 +659,7 @@ export type Database = {
           id?: string
           notes?: string | null
           property_id?: string
-          status?: string
+              status?: Database["public"]["Enums"]["deal_status"]
           updated_at?: string
         }
         Relationships: [
@@ -680,7 +680,7 @@ export type Database = {
         ]
       }
       debt_installments: {
-        Row: {
+          Row: {
           amount: number
           created_at: string
           debt_id: string
@@ -703,7 +703,7 @@ export type Database = {
           notes?: string | null
           paid_amount?: number | null
           paid_at?: string | null
-          status?: string
+            status?: string
           updated_at?: string
         }
         Update: {
@@ -716,7 +716,7 @@ export type Database = {
           notes?: string | null
           paid_amount?: number | null
           paid_at?: string | null
-          status?: string
+            status?: string
           updated_at?: string
         }
         Relationships: [
@@ -741,7 +741,7 @@ export type Database = {
           notification_type: string
           scheduled_for: string
           sent_at: string | null
-          status: string
+              status: string
           target_user_id: string | null
           title: string
         }
@@ -756,7 +756,7 @@ export type Database = {
           notification_type: string
           scheduled_for: string
           sent_at?: string | null
-          status?: string
+              status?: string
           target_user_id?: string | null
           title: string
         }
@@ -771,7 +771,7 @@ export type Database = {
           notification_type?: string
           scheduled_for?: string
           sent_at?: string | null
-          status?: string
+              status?: string
           target_user_id?: string | null
           title?: string
         }
@@ -792,7 +792,7 @@ export type Database = {
           },
         ]
       }
-      debts: {
+        debts: {
         Row: {
           amount: number
           auto_deduct_from_commission: boolean | null
@@ -814,7 +814,7 @@ export type Database = {
           payment_method: string | null
           priority_level: number | null
           recorded_by: string
-          status: string
+          status: Database["public"]["Enums"]["debt_status"]
           updated_at: string
         }
         Insert: {
@@ -838,7 +838,7 @@ export type Database = {
           payment_method?: string | null
           priority_level?: number | null
           recorded_by: string
-          status?: string
+          status?: Database["public"]["Enums"]["debt_status"]
           updated_at?: string
         }
         Update: {
@@ -862,7 +862,7 @@ export type Database = {
           payment_method?: string | null
           priority_level?: number | null
           recorded_by?: string
-          status?: string
+          status?: Database["public"]["Enums"]["debt_status"]
           updated_at?: string
         }
         Relationships: []
@@ -1194,7 +1194,7 @@ export type Database = {
           service_name: string
           service_type: string
           stage_order: number | null
-          status: string
+            status: string
           timeline_stages: Json | null
           updated_at: string
           workflow_stage: string | null
@@ -1224,7 +1224,7 @@ export type Database = {
           service_name: string
           service_type: string
           stage_order?: number | null
-          status?: string
+            status?: string
           timeline_stages?: Json | null
           updated_at?: string
           workflow_stage?: string | null
@@ -1254,7 +1254,7 @@ export type Database = {
           service_name?: string
           service_type?: string
           stage_order?: number | null
-          status?: string
+            status?: string
           timeline_stages?: Json | null
           updated_at?: string
           workflow_stage?: string | null
@@ -1448,7 +1448,7 @@ export type Database = {
           phone: string
           preferred_language: string
           preferred_location: string | null
-          property_type: string
+          property_type: Database["public"]["Enums"]["property_type"]
           purchase_purpose: string
           stage: string
           updated_at: string | null
@@ -1473,7 +1473,7 @@ export type Database = {
           phone: string
           preferred_language?: string
           preferred_location?: string | null
-          property_type: string
+          property_type: Database["public"]["Enums"]["property_type"]
           purchase_purpose: string
           stage?: string
           updated_at?: string | null
@@ -1498,7 +1498,7 @@ export type Database = {
           phone?: string
           preferred_language?: string
           preferred_location?: string | null
-          property_type?: string
+          property_type?: Database["public"]["Enums"]["property_type"]
           purchase_purpose?: string
           stage?: string
           updated_at?: string | null
@@ -1531,7 +1531,7 @@ export type Database = {
           metadata: Json | null
           notification_type: string
           sent_at: string | null
-          status: string
+            status: string
           title: string
         }
         Insert: {
@@ -1729,8 +1729,8 @@ export type Database = {
           listed_by: string
           location: string
           price: number
-          property_type: string
-          status: string
+          property_type: Database["public"]["Enums"]["property_type"]
+          status: Database["public"]["Enums"]["property_status"]
           title: string
           updated_at: string
         }
@@ -1747,8 +1747,8 @@ export type Database = {
           listed_by: string
           location: string
           price: number
-          property_type: string
-          status?: string
+          property_type: Database["public"]["Enums"]["property_type"]
+          status?: Database["public"]["Enums"]["property_status"]
           title: string
           updated_at?: string
         }
@@ -1765,8 +1765,8 @@ export type Database = {
           listed_by?: string
           location?: string
           price?: number
-          property_type?: string
-          status?: string
+          property_type?: Database["public"]["Enums"]["property_type"]
+          status?: Database["public"]["Enums"]["property_status"]
           title?: string
           updated_at?: string
         }
@@ -2039,8 +2039,8 @@ export type Database = {
           owner_phone: string
           property_address: string
           property_title: string
-          property_type: string
-          status: string
+          property_type: Database["public"]["Enums"]["property_type"]
+          status: Database["public"]["Enums"]["property_status"]
           unit_number: string | null
           updated_at: string
         }
@@ -2061,8 +2061,8 @@ export type Database = {
           owner_phone: string
           property_address: string
           property_title: string
-          property_type?: string
-          status?: string
+          property_type?: Database["public"]["Enums"]["property_type"]
+          status?: Database["public"]["Enums"]["property_status"]
           unit_number?: string | null
           updated_at?: string
         }
@@ -2083,8 +2083,8 @@ export type Database = {
           owner_phone?: string
           property_address?: string
           property_title?: string
-          property_type?: string
-          status?: string
+          property_type?: Database["public"]["Enums"]["property_type"]
+          status?: Database["public"]["Enums"]["property_status"]
           unit_number?: string | null
           updated_at?: string
         }
@@ -2901,7 +2901,7 @@ export type Database = {
           odometer_reading: number | null
           purchase_date: string | null
           purchase_price: number | null
-          status: string
+          status: Database["public"]["Enums"]["vehicle_status"]
           updated_at: string
           year: number
         }
@@ -2921,7 +2921,7 @@ export type Database = {
           odometer_reading?: number | null
           purchase_date?: string | null
           purchase_price?: number | null
-          status?: string
+          status?: Database["public"]["Enums"]["vehicle_status"]
           updated_at?: string
           year: number
         }
@@ -2941,7 +2941,7 @@ export type Database = {
           odometer_reading?: number | null
           purchase_date?: string | null
           purchase_price?: number | null
-          status?: string
+          status?: Database["public"]["Enums"]["vehicle_status"]
           updated_at?: string
           year?: number
         }
@@ -3291,6 +3291,12 @@ export type Database = {
     }
     Enums: {
       app_role: "admin" | "accountant" | "employee"
+      property_type: "villa" | "apartment" | "land" | "commercial"
+      property_status: "available" | "rented" | "sold" | "reserved"
+      deal_status: "open" | "closed" | "cancelled"
+      commission_status: "pending" | "paid" | "cancelled"
+      debt_status: "pending" | "paid" | "overdue" | "cancelled"
+      vehicle_status: "active" | "maintenance" | "inactive"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/20250804090330_1af4e930-76d7-4b74-875e-6e5a630f82e9.sql
+++ b/supabase/migrations/20250804090330_1af4e930-76d7-4b74-875e-6e5a630f82e9.sql
@@ -1,0 +1,43 @@
+-- Define enum types for properties and related tables
+CREATE TYPE public.property_type AS ENUM ('villa', 'apartment', 'land', 'commercial');
+CREATE TYPE public.property_status AS ENUM ('available', 'rented', 'sold', 'reserved');
+CREATE TYPE public.deal_status AS ENUM ('open', 'closed', 'cancelled');
+CREATE TYPE public.commission_status AS ENUM ('pending', 'paid', 'cancelled');
+CREATE TYPE public.debt_status AS ENUM ('pending', 'paid', 'overdue', 'cancelled');
+CREATE TYPE public.vehicle_status AS ENUM ('active', 'maintenance', 'inactive');
+
+-- Drop existing check constraints
+ALTER TABLE public.properties DROP CONSTRAINT IF EXISTS properties_property_type_check;
+ALTER TABLE public.properties DROP CONSTRAINT IF EXISTS properties_status_check;
+ALTER TABLE public.deals DROP CONSTRAINT IF EXISTS deals_status_check;
+ALTER TABLE public.commissions DROP CONSTRAINT IF EXISTS commissions_status_check;
+ALTER TABLE public.debts DROP CONSTRAINT IF EXISTS debts_status_check;
+ALTER TABLE public.vehicles DROP CONSTRAINT IF EXISTS vehicles_status_check;
+
+-- Alter columns to use enums
+ALTER TABLE public.properties
+  ALTER COLUMN property_type TYPE public.property_type USING property_type::public.property_type,
+  ALTER COLUMN status TYPE public.property_status USING status::public.property_status,
+  ALTER COLUMN status SET DEFAULT 'available';
+
+ALTER TABLE public.rental_properties
+  ALTER COLUMN property_type TYPE public.property_type USING property_type::public.property_type,
+  ALTER COLUMN property_type SET DEFAULT 'apartment',
+  ALTER COLUMN status TYPE public.property_status USING status::public.property_status,
+  ALTER COLUMN status SET DEFAULT 'available';
+
+ALTER TABLE public.deals
+  ALTER COLUMN status TYPE public.deal_status USING status::public.deal_status,
+  ALTER COLUMN status SET DEFAULT 'open';
+
+ALTER TABLE public.commissions
+  ALTER COLUMN status TYPE public.commission_status USING status::public.commission_status,
+  ALTER COLUMN status SET DEFAULT 'pending';
+
+ALTER TABLE public.debts
+  ALTER COLUMN status TYPE public.debt_status USING status::public.debt_status,
+  ALTER COLUMN status SET DEFAULT 'pending';
+
+ALTER TABLE public.vehicles
+  ALTER COLUMN status TYPE public.vehicle_status USING status::public.vehicle_status,
+  ALTER COLUMN status SET DEFAULT 'active';


### PR DESCRIPTION
## Summary
- define dedicated enum types for property categories and various record statuses
- swap text fields in property-related tables to use new enums
- align generated supabase TypeScript types with the enum-based schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689076c76e2c83288033dc187ea6f40f