### PR TITLE
refactor: centralize permission logic with dynamic source

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,11 +1,11 @@
 import { ReactNode, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
-import { useRoleAccess, RolePermissions } from '@/hooks/useRoleAccess';
+import { useRoleAccess, PermissionKey } from '@/hooks/useRoleAccess';
 
 interface ProtectedRouteProps {
   children: ReactNode;
-  requiredPermission: keyof RolePermissions;
+  requiredPermission: PermissionKey;
   fallback?: ReactNode;
 }
 


### PR DESCRIPTION
## Summary
- rely on `usePermissions` for role access checks and remove static role tables
- update `ProtectedRoute` to use new permission key type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68909a66f5b48328aba16e6ed07475ce