### PR TITLE
refactor: centralize route protection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,14 @@ const App = () => (
         <BrowserRouter>
           <AppLayout>
             <Routes>
-              <Route path="/" element={<DashboardHome />} />
+              <Route
+                path="/"
+                element={
+                  <ProtectedRoute requiredPermission="crmAccess">
+                    <DashboardHome />
+                  </ProtectedRoute>
+                }
+              />
               <Route path="/auth" element={<Auth />} />
               
               {/* CRM Routes - Admin and some for employees */}
@@ -254,7 +261,14 @@ const App = () => (
               } />
               
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
+              <Route
+                path="*"
+                element={
+                  <ProtectedRoute requiredPermission="crmAccess">
+                    <NotFound />
+                  </ProtectedRoute>
+                }
+              />
             </Routes>
           </AppLayout>
         </BrowserRouter>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,11 +1,11 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useNavigate, useLocation } from "react-router-dom";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Bell, LogOut } from "lucide-react";
+import { LogOut } from "lucide-react";
 import NotificationCenter from '@/components/notifications/NotificationCenter';
 import { useToast } from "@/hooks/use-toast";
 
@@ -18,12 +18,6 @@ export function AppLayout({ children }: AppLayoutProps) {
   const { toast } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
-
-  useEffect(() => {
-    if (!loading && !user && location.pathname !== "/auth") {
-      navigate("/auth");
-    }
-  }, [user, loading, navigate, location.pathname]);
 
   const handleSignOut = async () => {
     try {
@@ -53,13 +47,9 @@ export function AppLayout({ children }: AppLayoutProps) {
     );
   }
 
-  // Don't show layout for auth page
-  if (location.pathname === "/auth") {
+  // Don't show layout for auth page or unauthenticated users
+  if (location.pathname === "/auth" || !user) {
     return <>{children}</>;
-  }
-
-  if (!user) {
-    return null;
   }
 
   return (

--- a/src/pages/RoleManagement.tsx
+++ b/src/pages/RoleManagement.tsx
@@ -1,6 +1,4 @@
 import { useState } from "react";
-import { useAuth } from "@/hooks/useAuth";
-import { useRoleAccess } from "@/hooks/useRoleAccess";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -29,13 +27,7 @@ interface UserProfile {
 }
 
 export default function RoleManagement() {
-  const { requirePermission } = useRoleAccess();
   const queryClient = useQueryClient();
-
-  // Check permission on component mount
-  if (!requirePermission('canManageRoles')) {
-    return null;
-  }
 
   const { data: users, isLoading } = useQuery({
     queryKey: ['users'],

--- a/src/pages/reports/EmployeeReports.tsx
+++ b/src/pages/reports/EmployeeReports.tsx
@@ -32,13 +32,8 @@ interface EmployeeReport {
 }
 
 export default function EmployeeReports() {
-  const { checkPermission, requirePermission, userRole } = useRoleAccess();
+  const { userRole } = useRoleAccess();
   const [searchTerm, setSearchTerm] = useState("");
-
-  // Check permissions
-  if (!requirePermission('canViewAllStaff') && userRole !== 'employee') {
-    return null;
-  }
 
   const { data: employeeReports, isLoading } = useQuery({
     queryKey: ['employee-reports'],

--- a/src/pages/reports/VehicleReports.tsx
+++ b/src/pages/reports/VehicleReports.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useRoleAccess } from "@/hooks/useRoleAccess";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,13 +33,7 @@ interface VehicleReport {
 }
 
 export default function VehicleReports() {
-  const { requirePermission } = useRoleAccess();
   const [searchTerm, setSearchTerm] = useState("");
-
-  // Check permissions
-  if (!requirePermission('canViewAllVehicles')) {
-    return null;
-  }
 
   const { data: vehicleReports, isLoading } = useQuery({
     queryKey: ['vehicle-reports'],

--- a/src/pages/reports/index.tsx
+++ b/src/pages/reports/index.tsx
@@ -90,15 +90,10 @@ const reportSections = [
 ];
 
 export default function ReportsIndex() {
-  const { checkPermission, requirePermission } = useRoleAccess();
-
-  // Check if user has permission to view reports
-  if (!requirePermission('canViewAllReports')) {
-    return null;
-  }
+  const { checkPermission } = useRoleAccess();
 
   // Filter sections based on user permissions
-  const availableSections = reportSections.filter(section => 
+  const availableSections = reportSections.filter(section =>
     checkPermission(section.requiredPermission)
   );
 


### PR DESCRIPTION
## Summary
- rely on `ProtectedRoute` for authentication and permission checks
- remove redundant permission guards in reports and role management pages
- add protection to root and fallback routes

## Testing
- `npm ci` *(fails: peer dependency conflict for jspdf and jspdf-autotable)*

------
https://chatgpt.com/codex/tasks/task_e_68909a60f7e883288b7405ca7f20c9a1