### PR TITLE
refactor: extract reusable header component

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,21 +1,17 @@
 import { ReactNode, useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { useNavigate, useLocation } from "react-router-dom";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
-import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Bell, LogOut } from "lucide-react";
-import NotificationCenter from '@/components/notifications/NotificationCenter';
-import { useToast } from "@/hooks/use-toast";
+import NotificationCenter from "@/components/notifications/NotificationCenter";
+import { Header } from "./Header";
 
 interface AppLayoutProps {
   children: ReactNode;
 }
 
 export function AppLayout({ children }: AppLayoutProps) {
-  const { user, profile, signOut, loading } = useAuth();
-  const { toast } = useToast();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -24,23 +20,6 @@ export function AppLayout({ children }: AppLayoutProps) {
       navigate("/auth");
     }
   }, [user, loading, navigate, location.pathname]);
-
-  const handleSignOut = async () => {
-    try {
-      await signOut();
-      toast({
-        title: "تم تسجيل الخروج بنجاح",
-        description: "نراك قريباً!",
-      });
-      navigate("/auth");
-    } catch (error) {
-      toast({
-        title: "خطأ في تسجيل الخروج",
-        description: "يرجى المحاولة مرة أخرى",
-        variant: "destructive",
-      });
-    }
-  };
 
   if (loading) {
     return (
@@ -65,49 +44,9 @@ export function AppLayout({ children }: AppLayoutProps) {
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
-        {/* Header */}
-        <header className="fixed top-0 left-0 right-0 h-16 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border z-40">
-          <div className="h-full px-4 flex items-center justify-between">
-            <div className="flex items-center space-x-4 space-x-reverse">
-              <SidebarTrigger className="hover:bg-accent hover:text-accent-foreground" />
-              
-              {profile && (
-                <div className="hidden md:flex items-center space-x-3 space-x-reverse">
-                  <Avatar className="h-10 w-10">
-                    <AvatarImage src={profile.avatar_url} alt={`${profile.first_name} ${profile.last_name}`} />
-                    <AvatarFallback className="text-sm font-medium bg-primary/10 text-primary">
-                      {profile.first_name?.[0]}{profile.last_name?.[0]}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <h1 className="text-xl font-bold text-foreground">
-                      مرحباً، {profile.first_name} {profile.last_name}!
-                    </h1>
-                    <p className="text-sm text-muted-foreground">
-                      {profile.role === 'admin' ? 'لوحة تحكم المدير' : 
-                       profile.role === 'accountant' ? 'لوحة تحكم المحاسب' : 
-                       'لوحة تحكم الموظف'}
-                    </p>
-                  </div>
-                </div>
-              )}
-            </div>
-            
-            <div className="flex items-center space-x-2 space-x-reverse">
-              <NotificationCenter />
-              
-              <Button
-                variant="ghost" 
-                size="sm" 
-                onClick={handleSignOut}
-                className="text-destructive hover:text-destructive hover:bg-destructive/10"
-              >
-                <LogOut className="h-4 w-4 ml-2" />
-                خروج
-              </Button>
-            </div>
-          </div>
-        </header>
+        <Header>
+          <NotificationCenter />
+        </Header>
 
         {/* Sidebar */}
         <AppSidebar />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,81 @@
+import { ReactNode } from "react";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { LogOut } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { useNavigate } from "react-router-dom";
+
+interface HeaderProps {
+  children?: ReactNode;
+}
+
+export function Header({ children }: HeaderProps) {
+  const { profile, signOut } = useAuth();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    try {
+      await signOut();
+      toast({
+        title: "تم تسجيل الخروج بنجاح",
+        description: "نراك قريباً!",
+      });
+      navigate("/auth");
+    } catch (error) {
+      toast({
+        title: "خطأ في تسجيل الخروج",
+        description: "يرجى المحاولة مرة أخرى",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <header className="fixed top-0 left-0 right-0 h-16 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border z-40">
+      <div className="h-full px-4 flex items-center justify-between">
+        <div className="flex items-center space-x-4 space-x-reverse">
+          <SidebarTrigger className="hover:bg-accent hover:text-accent-foreground" />
+
+          {profile && (
+            <div className="hidden md:flex items-center space-x-3 space-x-reverse">
+              <Avatar className="h-10 w-10">
+                <AvatarImage src={profile.avatar_url} alt={`${profile.first_name} ${profile.last_name}`} />
+                <AvatarFallback className="text-sm font-medium bg-primary/10 text-primary">
+                  {profile.first_name?.[0]}
+                  {profile.last_name?.[0]}
+                </AvatarFallback>
+              </Avatar>
+              <div>
+                <h1 className="text-xl font-bold text-foreground">
+                  مرحباً، {profile.first_name} {profile.last_name}!
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  {profile.role === 'admin' ? 'لوحة تحكم المدير' :
+                   profile.role === 'accountant' ? 'لوحة تحكم المحاسب' :
+                   'لوحة تحكم الموظف'}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center space-x-2 space-x-reverse">
+          {children}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleSignOut}
+            className="text-destructive hover:text-destructive hover:bg-destructive/10"
+          >
+            <LogOut className="h-4 w-4 ml-2" />
+            خروج
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}
+

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,79 +1,24 @@
 import { ReactNode } from "react";
-import { useAuth } from "@/hooks/useAuth";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "./AppSidebar";
 import { Button } from "@/components/ui/button";
-import { Bell, LogOut } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
-import { useNavigate } from "react-router-dom";
+import { Bell } from "lucide-react";
+import { Header } from "./Header";
 
 interface MainLayoutProps {
   children: ReactNode;
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
-  const { profile, signOut } = useAuth();
-  const { toast } = useToast();
-  const navigate = useNavigate();
-
-  const handleSignOut = async () => {
-    try {
-      await signOut();
-      toast({
-        title: "تم تسجيل الخروج بنجاح",
-        description: "نراك قريباً!",
-      });
-      navigate("/auth");
-    } catch (error) {
-      toast({
-        title: "خطأ في تسجيل الخروج",
-        description: "يرجى المحاولة مرة أخرى",
-        variant: "destructive",
-      });
-    }
-  };
-
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
-        {/* Header */}
-        <header className="fixed top-0 left-0 right-0 h-16 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border z-40">
-          <div className="h-full px-4 flex items-center justify-between">
-            <div className="flex items-center space-x-4 space-x-reverse">
-              <SidebarTrigger className="hover:bg-accent hover:text-accent-foreground" />
-              
-              {profile && (
-                <div className="hidden md:block">
-                  <h1 className="text-xl font-bold text-foreground">
-                    مرحباً، {profile.first_name}!
-                  </h1>
-                  <p className="text-sm text-muted-foreground">
-                    {profile.role === 'admin' ? 'لوحة تحكم المدير' : 
-                     profile.role === 'accountant' ? 'لوحة تحكم المحاسب' : 
-                     'لوحة تحكم الموظف'}
-                  </p>
-                </div>
-              )}
-            </div>
-            
-            <div className="flex items-center space-x-2 space-x-reverse">
-              <Button variant="ghost" size="sm" className="relative">
-                <Bell className="h-4 w-4" />
-                <span className="absolute -top-1 -right-1 h-2 w-2 bg-destructive rounded-full"></span>
-              </Button>
-              
-              <Button 
-                variant="ghost" 
-                size="sm" 
-                onClick={handleSignOut}
-                className="text-destructive hover:text-destructive hover:bg-destructive/10"
-              >
-                <LogOut className="h-4 w-4 ml-2" />
-                خروج
-              </Button>
-            </div>
-          </div>
-        </header>
+        <Header>
+          <Button variant="ghost" size="sm" className="relative">
+            <Bell className="h-4 w-4" />
+            <span className="absolute -top-1 -right-1 h-2 w-2 bg-destructive rounded-full"></span>
+          </Button>
+        </Header>
 
         {/* Sidebar */}
         <AppSidebar />


### PR DESCRIPTION
## Summary
- create shared `Header` with profile info, notifications slot and sign-out handling
- use new `Header` in `AppLayout` and `MainLayout`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68909a59a5ac8328bfe53e1253bf6fe6