### PR TITLE
feat: add employee user creation function

### DIFF
--- a/supabase/functions/create-employee-user/index.ts
+++ b/supabase/functions/create-employee-user/index.ts
@@ -1,0 +1,79 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+interface CreateEmployeeRequest {
+  email: string;
+  password: string;
+  first_name: string;
+  last_name: string;
+  phone?: string | null;
+  role: string;
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    );
+
+    const body = (await req.json()) as CreateEmployeeRequest;
+    const { email, password, first_name, last_name, phone, role } = body;
+
+    if (!email || !password || !first_name || !last_name || !role) {
+      throw new Error("Missing required fields");
+    }
+
+    const { data: userData, error: userError } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+
+    if (userError || !userData.user) {
+      throw userError || new Error("Failed to create user");
+    }
+
+    const user = userData.user;
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from("profiles")
+      .insert({
+        user_id: user.id,
+        email,
+        first_name,
+        last_name,
+        phone,
+        role,
+      })
+      .select()
+      .single();
+
+    if (profileError) {
+      await supabaseAdmin.auth.admin.deleteUser(user.id);
+      throw profileError;
+    }
+
+    return new Response(
+      JSON.stringify({ profile, temporary_password: password }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 200 }
+    );
+  } catch (error) {
+    console.error("Error creating employee user:", error);
+    return new Response(
+      JSON.stringify({ message: (error as Error).message }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 400 }
+    );
+  }
+});
+


### PR DESCRIPTION
## Summary
- add `create-employee-user` edge function to create auth user and profile, returning temporary password

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js')*
- `supabase functions deploy create-employee-user` *(fails: command not found: supabase)*

------
https://chatgpt.com/codex/tasks/task_e_6890a05cd6ec8328b3df6770b404ac4b